### PR TITLE
Added in hard mode and disabled rapid clicking cheat

### DIFF
--- a/pantone_game_svelte/src/lib/components/ColourNameGuess.svelte
+++ b/pantone_game_svelte/src/lib/components/ColourNameGuess.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from "svelte";
 
-  export let correct_answer = "not yet set";
+  export let correct_answer = "loading";
   export let guessing;
   export let correct;
   export let randomiser;

--- a/pantone_game_svelte/src/lib/components/ColourSquare.svelte
+++ b/pantone_game_svelte/src/lib/components/ColourSquare.svelte
@@ -4,6 +4,7 @@
   export let correct_answer;
   export let checkAnswer;
   export let mode;
+  export let square_hex_code = "#00000";
 </script>
 
 <div class="colour-name-pair">
@@ -12,6 +13,7 @@
     on:click={() => checkAnswer(correct_answer, box_colour_name, mode)}
   >
   </button>
+  <p class="colour-squaure-hex-code">{square_hex_code}</p>
   {#if hidden}
     <p class="colour-name main-text">{box_colour_name.replaceAll("-", " ")}</p>
   {:else}
@@ -63,6 +65,7 @@
       display: flex;
       flex-direction: column;
       margin: auto;
+      pointer-events: var(--disable_clicks);
     }
 
     .colour-name {

--- a/pantone_game_svelte/src/routes/+page.svelte
+++ b/pantone_game_svelte/src/routes/+page.svelte
@@ -23,6 +23,7 @@
   $: correct = false;
   $: square_sizes = [8, 8, 8, 8];
   $: mode = 1;
+  $: clicked = false;
 
   const max_score = 10;
   $: training_mode_toggle = "off";
@@ -36,14 +37,37 @@
     //Reset the arrays - don't remove these just for refactoring, you plantpot -- and don't put them in the loop!!!
     hex_value_array = [];
     colour_name_array = [];
-    for (let step = 0; step < 4; step++) {
-      let selector = Math.floor(Math.random() * colourJSON["names"].length);
-      hex_value_array = [...hex_value_array, colourJSON["values"][selector]];
-      colour_name_array = [...colour_name_array, colourJSON["names"][selector]];
+
+    if (mode < 2) {
+      for (let step = 0; step < 4; step++) {
+        let selector = Math.floor(Math.random() * colourJSON["names"].length);
+        hex_value_array = [...hex_value_array, colourJSON["values"][selector]];
+        colour_name_array = [
+          ...colour_name_array,
+          colourJSON["names"][selector],
+        ];
+      }
+    } else {
+      let selector = Math.floor(
+        Math.random() * (colourJSON["names"].length - 1)
+      );
+      if (selector < 2) {
+        selector += 2;
+      }
+      for (let step = -2; step < 2; step++) {
+        hex_value_array = [
+          ...hex_value_array,
+          colourJSON["values"][selector + step],
+        ];
+        colour_name_array = [
+          ...colour_name_array,
+          colourJSON["names"][selector + step],
+        ];
+      }
     }
-    console.log(colour_name_array);
     correct_answer = colour_name_array[Math.floor(Math.random() * 4)];
     guessing = true;
+    clicked = false;
   }
 
   function randomiser(array) {
@@ -67,23 +91,30 @@
 
   function adjustScoreDown(score, mode) {
     if (mode < 1) {
-      return --score;
+      if (score > 0) {
+        return --score;
+      } else {
+        return 0;
+      }
     } else {
       return (score = Math.floor(score / 2));
     }
   }
 
   function checkAnswer(correct_answer, box_colour_name, mode) {
-    guessing = false;
-    correct = box_colour_name === correct_answer;
-    if (!(score === max_score) && !hidden) {
-      if (correct) {
-        score = adjustScoreUp(score);
-      } else {
-        score = adjustScoreDown(score, mode);
+    if (!clicked) {
+      clicked = true;
+      guessing = false;
+      correct = box_colour_name === correct_answer;
+      if (!(score === max_score) && !hidden) {
+        if (correct) {
+          score = adjustScoreUp(score);
+        } else {
+          score = adjustScoreDown(score, mode);
+        }
       }
+      setTimeout(setGame, 1500);
     }
-    setTimeout(setGame, 1500);
   }
 
   function setMode(modeValue) {
@@ -111,11 +142,13 @@
     <ColourSquare
       {checkAnswer}
       --square-colour={hex_value_array[i]}
+      square_hex_code={hex_value_array[i]}
       --square-size={square_sizes[i] + "em"}
       box_colour_name={colour_name_array[i]}
       {hidden}
       {correct_answer}
       {mode}
+      --disable_clicks={guessing}
     />
   {/each}
 </div>


### PR DESCRIPTION
- Added in hard mode, where the colours are selected from a set of 4 sequential colours, as opposed to being selected from the whole set each time (so you are shown similar colours each time)
- Added in a new variable to colour squares to track whether a guess has been made or not - if so, it disables the checkAnswer function, so they can't rapidly click the right answer a bunch of times before reload
- Fixed the overflow bug for going beneath 0 points on easy mode