### PR TITLE
Removed 5px rule on score on desktop size

### DIFF
--- a/pantone_game_svelte/src/lib/components/Score.svelte
+++ b/pantone_game_svelte/src/lib/components/Score.svelte
@@ -65,9 +65,5 @@
     .progress-bar {
       margin: auto;
     }
-
-    .score {
-      font-size: 5px;
-    }
   }
 </style>


### PR DESCRIPTION
Leftover from when I was testing font sizes on mobile